### PR TITLE
Update source URL for Hello Metaverse to source link

### DIFF
--- a/src/_data/examples.yml
+++ b/src/_data/examples.yml
@@ -17,7 +17,7 @@ showcase:
 - section: showcase
   slug: hello-metaverse
   scene_url: /examples/hello-metaverse/
-  source_url: https://aframe-hello-metaverse.glitch.me
+  source_url: https://glitch.com/~aframe-hello-metaverse
   title: Hello Metaverse
   author: Ada Rose Edwards (@lady_ada_king)
 


### PR DESCRIPTION
The existing "View Source" link just linked to the rendered page, with no link to the actual source. This links to the project's homepage, which does give access to the source.